### PR TITLE
Update Corese GUI to 5.0.0

### DIFF
--- a/fr.inria.corese.CoreseGui.yml
+++ b/fr.inria.corese.CoreseGui.yml
@@ -1,53 +1,77 @@
 app-id: fr.inria.corese.CoreseGui
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: "25.08"
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk
-command: run.sh
+  - org.freedesktop.Sdk.Extension.openjdk25
+command: corese-gui
 
 finish-args:
-  - --env=PATH=/app/jre/bin:/usr/bin:/app/bin/
+  # Needed for remote URI loading, federated queries and update checks.
   - --share=network
-  - --share=ipc
-  - --filesystem=home
+  # Allow talking to IBus for input method handling (dead keys / composition).
+  - --talk-name=org.freedesktop.IBus
+  - --talk-name=org.freedesktop.IBus.*
+  # JavaFX currently needs X11/XWayland for reliable startup in Flatpak.
   - --socket=x11
+  # Improves compatibility/performance for JavaFX rendering.
+  - --share=ipc
+  # Hardware acceleration for JavaFX rendering (reduces visual glitches).
   - --device=dri
+  # JavaFX file chooser currently needs explicit filesystem access.
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+  - --filesystem=xdg-desktop
 
 modules:
   - name: openjdk
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/openjdk/install.sh
+      - /usr/lib/sdk/openjdk25/install.sh
 
   - name: corese-gui
     buildsystem: simple
     build-commands:
       - install -Dm644 corese-gui-standalone.jar /app/bin/corese-gui-standalone.jar
-      - install -Dm755 packaging/flatpak/scripts/run.sh /app/bin/run.sh
+      - install -Dm755 packaging/flatpak/scripts/run.sh /app/bin/corese-gui
+      - install -Dm644 src/main/resources/images/startup-splash-primer-dark.png /app/share/corese-gui/startup-splash-primer-dark.png
       - install -Dm644 packaging/flatpak/appdata/${FLATPAK_ID}.appdata.xml /app/share/metainfo/${FLATPAK_ID}.appdata.xml
       - install -Dm644 packaging/flatpak/appdata/${FLATPAK_ID}.desktop /app/share/applications/${FLATPAK_ID}.desktop
       - install -Dm644 packaging/assets/logo/${FLATPAK_ID}.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
 
     sources:
-      # jar file from GitHub release
+      # Linux x86_64 standalone JAR from GitHub release assets.
       - type: file
-        url: https://github.com/corese-stack/corese-gui-swing/releases/download/v4.6.1/corese-gui-standalone.jar
-        sha256: 24057fd0eebf231a6c0c68dc59db73068d9685baa6afa9ddba1a7f0ab7c72e0a
+        url: https://github.com/corese-stack/corese-gui/releases/download/v5.0.0/corese-gui-5.0.0-standalone-linux-x64.jar
+        sha256: fc2e2e4b18d6d4b11c6d8a6c614d5aa6a9c748fec22fd76ef2aceaab6cac68a9
+        dest-filename: corese-gui-standalone.jar
+        only-arches:
+          - x86_64
         x-checker-data:
           type: json
-          url: https://api.github.com/repos/corese-stack/corese-gui-swing/releases/latest
+          url: https://api.github.com/repos/corese-stack/corese-gui/releases/latest
           version-query: .tag_name
-          url-query: '"https://github.com/corese-stack/corese-gui-swing/releases/download/"
-            + $version + "/corese-gui-standalone.jar"'
+          url-query: '.assets[] | select(.name | endswith("-standalone-linux-x64.jar")) | .browser_download_url'
 
-      # appdata, desktop and icon files from GitHub repository
-      - type: archive
-        url: https://github.com/corese-stack/corese-gui-swing/archive/refs/tags/v4.6.1.tar.gz
-        sha256: 017412c2b7ae7199cfbc9913f94e9f7e6426036b3747aebd7c6e341e0ae1c597
+      # Linux arm64 standalone JAR from GitHub release assets.
+      - type: file
+        url: https://github.com/corese-stack/corese-gui/releases/download/v5.0.0/corese-gui-5.0.0-standalone-linux-arm64.jar
+        sha256: 743696d9bb387be1d2a2eed0af2340e1f933648621f557e4e7cb840cdb3dd549
+        dest-filename: corese-gui-standalone.jar
+        only-arches:
+          - aarch64
         x-checker-data:
           type: json
-          url: https://api.github.com/repos/corese-stack/corese-gui-swing/releases/latest
+          url: https://api.github.com/repos/corese-stack/corese-gui/releases/latest
           version-query: .tag_name
-          url-query: '"https://github.com/corese-stack/corese-gui-swing/archive/refs/tags/"
-            + $version + ".tar.gz"'
+          url-query: '.assets[] | select(.name | endswith("-standalone-linux-arm64.jar")) | .browser_download_url'
+
+      # appdata, desktop and icon files from GitHub repository.
+      - type: archive
+        url: https://github.com/corese-stack/corese-gui/archive/refs/tags/v5.0.0.tar.gz
+        sha256: 86a504a7d9e41a37077c3a2564ce504b3f66314284af230cb521f96cb8513a31
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/corese-stack/corese-gui/releases/latest
+          version-query: .tag_name
+          url-query: '"https://github.com/corese-stack/corese-gui/archive/refs/tags/" + $version + ".tar.gz"'


### PR DESCRIPTION
## Summary
- update Corese GUI from the old corese-gui-swing packaging to the new corese-gui Flatpak manifest
- bump the Flatpak runtime to 25.08 with OpenJDK 25
- pin the v5.0.0 standalone Linux artifacts and source archive checksums

## Validation
- flatpak-builder-lint manifest fr.inria.corese.CoreseGui.yml